### PR TITLE
Prevent base64 encoding from adding newlines

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/Hoopla.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/Hoopla.pm
@@ -129,7 +129,7 @@ sub refresh_token {
     my $ua = LWP::UserAgent->new;
     my $hoopla_user = C4::Context->config('hoopla_api_username');
     my $hoopla_pass = C4::Context->config('hoopla_api_password');
-    my $auth_string = "Basic " . encode_base64($hoopla_user.":".$hoopla_pass);
+    my $auth_string = "Basic " . encode_base64($hoopla_user.":".$hoopla_pass,'');
     my $response = $ua->post($uri_base . "/api/v1/get-token",'Authorization' => $auth_string);
     my $content = decode_json( $response->{_content});
 


### PR DESCRIPTION
By default, encode_base64 will break lines into 76 characters each. In this plugin, if you're using a long password, this means newlines get inserted into the auth string which prevents the user from authenticating against the Hoopla API correctly.